### PR TITLE
fix: Forestry Instant Previews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
+# Jekyll
 _site/
 .sass-cache/
 .jekyll-metadata
+
+## Bundler
+.bundle
+vendor/bundle
+
+## macOS
+.DS_Store

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "jekyll", "~> 3.8"
+
+group :jekyll_plugins do
+  gem "jekyll-feed"
+  gem "jekyll-seo-tag"
+  gem "jekyll-sitemap"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,70 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    colorator (1.1.0)
+    concurrent-ruby (1.1.5)
+    em-websocket (0.5.1)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0.6.0)
+    eventmachine (1.2.7)
+    ffi (1.11.3)
+    forwardable-extended (2.6.0)
+    http_parser.rb (0.6.0)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
+    jekyll (3.8.6)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      em-websocket (~> 0.5)
+      i18n (~> 0.7)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 2.0)
+      kramdown (~> 1.14)
+      liquid (~> 4.0)
+      mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
+      rouge (>= 1.7, < 4)
+      safe_yaml (~> 1.0)
+    jekyll-feed (0.13.0)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-sass-converter (1.5.2)
+      sass (~> 3.4)
+    jekyll-seo-tag (2.6.1)
+      jekyll (>= 3.3, < 5.0)
+    jekyll-sitemap (1.4.0)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    kramdown (1.17.0)
+    liquid (4.0.3)
+    listen (3.2.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    mercenary (0.3.6)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (4.0.1)
+    rb-fsevent (0.10.3)
+    rb-inotify (0.10.0)
+      ffi (~> 1.0)
+    rouge (3.13.0)
+    safe_yaml (1.0.5)
+    sass (3.7.4)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll (~> 3.8)
+  jekyll-feed
+  jekyll-seo-tag
+  jekyll-sitemap
+
+BUNDLED WITH
+   2.1.0.pre.3

--- a/_config-dev.yml
+++ b/_config-dev.yml
@@ -1,3 +1,2 @@
-url: http://127.0.0.1:4000
 sass:
   style: full

--- a/serve.sh
+++ b/serve.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-JEKYLL_ENV=development jekyll serve --config "_config.yml,_config-dev.yml"
+JEKYLL_ENV=development bundle exec jekyll serve --config _config.yml,_config-dev.yml


### PR DESCRIPTION
👋 Hi, Forestry support here

This PR aims at allowing Forestry Instant Previews to install dependencies with bundler. It adds a `Gemfile` to the project as recommended by the Jekyll documentation.

Please merge the fix, so that Vicky can preview posts before publishing on Forestry.

Thanks 🙏 